### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://idstudiotechnologies.visualstudio.com/df6c4db4-a891-4e7c-a356-d6b471b94595/d468f3a5-540a-444c-a2ac-9af90caee730/_apis/work/boardbadge/aa5c1bab-0c17-4499-92f9-d5e08d25b05e)](https://idstudiotechnologies.visualstudio.com/df6c4db4-a891-4e7c-a356-d6b471b94595/_boards/board/t/d468f3a5-540a-444c-a2ac-9af90caee730/Microsoft.RequirementCategory)
 # Gen7-Engine-Bug-Reporting
 Gen7 Engine bug reporting dedicaated GitHub.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#14](https://idstudiotechnologies.visualstudio.com/df6c4db4-a891-4e7c-a356-d6b471b94595/_workitems/edit/14). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.